### PR TITLE
Bug fix for finding buttons by value

### DIFF
--- a/lettuce_webdriver/tests/html_pages/basic_page.html
+++ b/lettuce_webdriver/tests/html_pages/basic_page.html
@@ -43,6 +43,7 @@
         </select>
 
         <input type="submit" name="submit" value="Submit!" />
+        <button type="submit" name="submit_tentative">Submit as tentative</button>
     </form>
     <a href="http://google.com/">Google</a>
     

--- a/lettuce_webdriver/tests/test_util.py
+++ b/lettuce_webdriver/tests/test_util.py
@@ -32,3 +32,10 @@ class TestUtil(unittest.TestCase):
         assert find_field(world.browser, 'text', 'username')
         assert find_field(world.browser, 'text', 'Username:')
         assert find_field(world.browser, 'text', 'user')
+
+    def test_find_button(self):
+        from lettuce_webdriver.util import find_button
+        assert find_button(world.browser, 'submit')
+        assert find_button(world.browser, 'Submit!')
+        assert find_button(world.browser, 'submit_tentative')
+        assert find_button(world.browser, 'Submit as tentative')

--- a/lettuce_webdriver/util.py
+++ b/lettuce_webdriver/util.py
@@ -11,8 +11,13 @@ def element_id_by_label(browser, label):
 ## Field helper functions to locate select, textarea, and the other
 ## types of input fields (text, checkbox, radio)
 def field_xpath(field, attribute):
-    if field in ['select', 'textarea', 'button']:
+    if field in ['select', 'textarea']:
         return '//%s[@%s="%%s"]' % (field, attribute)
+    elif field == 'button':
+        if attribute == 'value':
+            return '//%s[contains(., "%%s")]' % (field, )
+        else:
+            return '//%s[@%s="%%s"]' % (field, attribute)
     elif field == 'option':
         return './/%s[@%s="%%s"]' % (field, attribute)
     else:


### PR DESCRIPTION
The <button> tag is special to other "buttons" (input[@type="submit"], ...) as that the text is enclosed by the start and closing tag and not stored in a "value" attribute.

Also adding a test case to test find_button().
