### PR TITLE
Bugfix: Use step variable instead of step decorator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@ trunk
 -----
 
 -   Adding a guard to fail properly if the field is not found.
+-   API change: wait_for_content now expects a step as the first parameter
 
 0.1.3
 -----

--- a/lettuce_webdriver/tests/test_util.py
+++ b/lettuce_webdriver/tests/test_util.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from lettuce import world
+from lettuce.core import Step
 from lettuce_webdriver.tests import html_pages
 
 def setUp():
@@ -39,3 +40,9 @@ class TestUtil(unittest.TestCase):
         assert find_button(world.browser, 'Submit!')
         assert find_button(world.browser, 'submit_tentative')
         assert find_button(world.browser, 'Submit as tentative')
+    
+    def test_wait_for_content(self):
+        from lettuce_webdriver.webdriver import wait_for_content
+        step = Step("foobar", [])
+        self.assertRaises(AssertionError, wait_for_content, step, world.browser, 'text not on the page', timeout=0)
+    

--- a/lettuce_webdriver/webdriver.py
+++ b/lettuce_webdriver/webdriver.py
@@ -23,7 +23,7 @@ def wait_for_elem(browser, xpath, timeout=15):
     return elems
 
 
-def wait_for_content(browser, content, timeout=15):
+def wait_for_content(step, browser, content, timeout=15):
     start = time.time()
     while time.time() - start < timeout:
         if content in world.browser.page_source:
@@ -106,7 +106,7 @@ def should_not_see_id(step, element_id):
 
 @step('I should see "([^"]+)" within (\d+) seconds?')
 def should_see_in_seconds(step, text, timeout):
-    wait_for_content(world.browser, text, int(timeout))
+    wait_for_content(step, world.browser, text, int(timeout))
 
 
 @step('I should see "([^"]+)"')


### PR DESCRIPTION
Previously, this would fail in **exit** with
AttributeError: 'function' object has no attribute 'sentence'

To do this, the wait_for_content API had to be changed and
now requires step as the first parameter.
