### PR TITLE
lettuce_webdriver throws exception with a recent selenium version

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.2.1
+-----
+
+-   Fix the guard from 0.2, incompatible with recent selenium versions.
+
 0.2
 ---
 

--- a/lettuce_webdriver/webdriver.py
+++ b/lettuce_webdriver/webdriver.py
@@ -157,7 +157,7 @@ def fill_in_textfield(step, field_name, value):
         text_field = find_field(world.browser, 'text', field_name) or \
             find_field(world.browser, 'textarea', field_name) or \
             find_field(world.browser, 'password', field_name)
-        assert_false(step, text_field == False,'Can not find a field named "%s"' % field_name)
+        assert_false(step, text_field is False,'Can not find a field named "%s"' % field_name)
         text_field.clear()
         text_field.send_keys(value)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-__version__ = '0.2'
+__version__ = '0.2.1'
 
 import os
 


### PR DESCRIPTION
It's incompatible with recent selenium versions: a `text_field == False` comparison tries to look up the id property of the boolean.

The patch includes a simple fix and a version bump.
