### PR TITLE
Move out of the way of the freezegun

### DIFF
--- a/lettuce_webdriver/css_selector_steps.py
+++ b/lettuce_webdriver/css_selector_steps.py
@@ -1,4 +1,4 @@
-import time
+from time import sleep
 
 from lettuce import step
 from lettuce import world
@@ -28,7 +28,7 @@ def load_script(browser, url):
     document.getElementsByTagName("head")[0].appendChild(script_tag);
     """, url)
 
-    time.sleep(1)
+    sleep(1)
 
 
 def find_elements_by_jquery(browser, selector):
@@ -134,7 +134,7 @@ def select_by_selector(step, selector):
     assert_true(step, len(selectors) > 0)
     selector = selectors[0]
     selector.click()
-    time.sleep(0.3)
+    sleep(0.3)
     option.click()
     assert_true(step, option.is_selected())
 

--- a/lettuce_webdriver/util.py
+++ b/lettuce_webdriver/util.py
@@ -1,7 +1,7 @@
 """Utility functions that combine steps to locate elements"""
 
 import operator
-import time
+from time import time, sleep
 
 from selenium.common.exceptions import NoSuchElementException
 
@@ -284,14 +284,14 @@ def wait_for(func):
     def wrapped(*args, **kwargs):
         timeout = kwargs.pop('timeout', 15)
 
-        start = time.time()
+        start = time()
         result = None
 
-        while time.time() - start < timeout:
+        while time() - start < timeout:
             result = func(*args, **kwargs)
             if result:
                 break
-            time.sleep(0.2)
+            sleep(0.2)
 
         return result
 


### PR DESCRIPTION
freezegun is used to mock the current time for testing.
Importing time as a module doesn't allow excluding LWD from freezing
time, making "within 2 seconds" steps stall.
